### PR TITLE
Launch info

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Header from './Components/Header/Header';
 import LaunchCard from './Components/LaunchCard/LaunchCard';
 
-import { Grid, createMuiTheme, ThemeProvider, Typography } from '@material-ui/core';
+import { Grid, createMuiTheme, ThemeProvider, Typography, CircularProgress } from '@material-ui/core';
 import { red } from '@material-ui/core/colors';
 
 import { getUpcomingLaunches } from './apiCalls';
@@ -49,6 +49,7 @@ class App extends React.Component {
   
   render() {
     const { darkMode, loading } = this.state;
+
     const theme = createMuiTheme({
       palette: {
         type: darkMode ? 'dark': 'light',
@@ -64,23 +65,24 @@ class App extends React.Component {
       typography: {
         h1: {
           color: darkMode ? red[400]: '#fff',
+          fontFamily: 'Pacifico, Roboto',
+          fontSize: 48,
         }
       }
-    })
+    });
+
     return (
       <ThemeProvider theme={theme}>
         <main style={{ backgroundColor: darkMode ? '#000': '#fafafa' }}>
           <Header toggleDarkMode={this.toggleDarkMode}/>
-          {loading ? <h1>Loading...</h1> : (
             <Grid
               container
               justify="center"
               alignItems="center"
               style={{ padding: '20px 0px'}}
             >
-              {this.renderUpcomingLaunches()}
+              { loading ? <CircularProgress color="inherit" /> : this.renderUpcomingLaunches()}
             </Grid>
-          )}
         </main>
       </ThemeProvider>
     );

--- a/src/Components/LaunchCard/LaunchCard.jsx
+++ b/src/Components/LaunchCard/LaunchCard.jsx
@@ -92,9 +92,11 @@ export default function LaunchCard({ launch }) {
               {probability}% Chance of Launch
             </Typography>
           )}
-          <Typography paragraph>
-            {missions[0].description}
-          </Typography>
+          {missions[0] && (
+            <Typography paragraph>
+              {missions[0].description}
+            </Typography>
+          )}
         </CardContent>
         <CardContent>
           {/* <CardMedia
@@ -104,7 +106,9 @@ export default function LaunchCard({ launch }) {
           /> */}
           <Typography paragraph>Rocket: {rocket.familyname}</Typography>
           {rocket.configuration && <Typography paragraph>Configuration: {rocket.configuration}</Typography>}
-          <Typography paragraph>Launching from  {location.pads[0].name}</Typography>
+          <Typography paragraph>Launching from</Typography>
+          <Typography paragraph>{location.name}</Typography>
+          <Typography paragraph>{location.pads[0].name}</Typography>
           <Typography paragraph>Status: {launch.status === 1 ? 'Green': launch.status ===2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</Typography>
           {(tbddate === 1 || tbdtime === 1) ? (
             <React.Fragment>


### PR DESCRIPTION
#### What's this PR do?
Basic setup and configuration. Adds the ability to toggle between light and dark mode. Brings in upcoming launch information. Implements basic launch cards to display data about launches.
#### Where should the reviewer start?
Run the application on localhost. After loading you should see upcoming launches displayed via launch cards. The user should be able to expand launch cards to see additional information. The user should be able to toggle between light and dark mode.
#### Any background context you want to provide?
Launch cards still need additional information and styling.
#### What are the relevant tickets?
#1 #6 #7 
#### Screenshots (if appropriate)
![Screen Shot 2020-07-06 at 10 50 50 AM](https://user-images.githubusercontent.com/25031031/86613228-e4915f80-bf76-11ea-8bbd-b3380ec383d9.png)
![Screen Shot 2020-07-06 at 10 51 00 AM](https://user-images.githubusercontent.com/25031031/86613234-e6f3b980-bf76-11ea-841d-b98402d0fd97.png)

