### PR TITLE
Past launches

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Header from './Components/Header/Header';
 import LaunchCard from './Components/LaunchCard/LaunchCard';
+import LaunchTimeframeToggle from './Components/LaunchTimeframeToggle/LaunchTimeframeToggle';
 
 import { Grid, createMuiTheme, ThemeProvider, Typography, CircularProgress } from '@material-ui/core';
 import { red } from '@material-ui/core/colors';
@@ -13,6 +14,7 @@ class App extends React.Component {
     darkMode: false,
     error: null,
     loading: true,
+    timeframe: false,
   };
 
   componentDidMount = async () => {
@@ -36,6 +38,39 @@ class App extends React.Component {
     const { darkMode } = this.state;
     await localStorage.setItem('darkMode', !darkMode);
     this.setState({ darkMode: !darkMode });
+  }
+
+  toggleLaunchTimeFrames = () => {
+    this.setState({ timeframe: !this.state.timeframe});
+  }
+
+  getTodaysDate = () => {
+    const today = new Date();
+    let day = today.getDate();
+    let month = today.getMonth() + 1;
+    const year = today.getFullYear();
+    
+    if(day < 10) {
+      day = `0${day}`;
+    }
+
+    if(month < 10) {
+      month = `0${month}`;
+    }
+
+    return `${month}/${day}/${year}`;
+  }
+
+  getOneMonthBackDate = () => {
+    const date = new Date();
+    date.setMonth(date.getMonth() -1);
+    let month = date.getMonth() + 1;
+    const year = date.getFullYear();
+
+    if(month < 10){
+      month = `0${month}`;
+    }
+    return `${month}/01/${year}`;
   }
 
   renderUpcomingLaunches = () => {
@@ -83,6 +118,7 @@ class App extends React.Component {
       <ThemeProvider theme={theme}>
         <main style={{ backgroundColor: darkMode ? '#000': '#fafafa' }}>
           <Header toggleDarkMode={this.toggleDarkMode} darkMode={darkMode}/>
+            <LaunchTimeframeToggle />
             <Grid
               container
               justify="center"

--- a/src/App.js
+++ b/src/App.js
@@ -17,16 +17,24 @@ class App extends React.Component {
 
   componentDidMount = async () => {
     try {
+      console.log('loading');
       const launches = await getUpcomingLaunches(10);
-      this.setState({ launches, loading: false });
+      const localThemePrefs = await localStorage.getItem('darkMode');
+      const darkMode = localThemePrefs ? JSON.parse(localThemePrefs): false;
+      await this.setState({
+        launches,
+        darkMode,
+        loading: false,
+      });
     } catch(e) {
       console.log(e);
       this.setState({ error: e, loading: false });
     }
   }
 
-  toggleDarkMode = () => {
+  toggleDarkMode = async () => {
     const { darkMode } = this.state;
+    await localStorage.setItem('darkMode', !darkMode);
     this.setState({ darkMode: !darkMode });
   }
 
@@ -74,7 +82,7 @@ class App extends React.Component {
     return (
       <ThemeProvider theme={theme}>
         <main style={{ backgroundColor: darkMode ? '#000': '#fafafa' }}>
-          <Header toggleDarkMode={this.toggleDarkMode}/>
+          <Header toggleDarkMode={this.toggleDarkMode} darkMode={darkMode}/>
             <Grid
               container
               justify="center"

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Header from './Components/Header/Header';
 import LaunchCard from './Components/LaunchCard/LaunchCard';
 
-import { Grid, createMuiTheme, ThemeProvider, Typography } from '@material-ui/core';
+import { Grid, createMuiTheme, ThemeProvider, Typography, CircularProgress } from '@material-ui/core';
 import { red } from '@material-ui/core/colors';
 
 import { getUpcomingLaunches } from './apiCalls';
@@ -49,6 +49,7 @@ class App extends React.Component {
   
   render() {
     const { darkMode, loading } = this.state;
+
     const theme = createMuiTheme({
       palette: {
         type: darkMode ? 'dark': 'light',
@@ -64,23 +65,24 @@ class App extends React.Component {
       typography: {
         h1: {
           color: darkMode ? red[400]: '#fff',
+          fontFamily: 'Pacifico, Roboto',
+          fontSize: 48,
         }
       }
-    })
+    });
+
     return (
       <ThemeProvider theme={theme}>
         <main style={{ backgroundColor: darkMode ? '#000': '#fafafa' }}>
           <Header toggleDarkMode={this.toggleDarkMode}/>
-          {loading ? <h1>Loading...</h1> : (
             <Grid
               container
               justify="center"
               alignItems="center"
               style={{ padding: '20px 0px'}}
             >
-              {this.renderUpcomingLaunches()}
+              { loading ? <CircularProgress color="inherit" /> : this.renderUpcomingLaunches()}
             </Grid>
-          )}
         </main>
       </ThemeProvider>
     );

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function Header({ darkMode, toggleDarkMode }) {
   const classes = useStyles();
+  const isDarkMode = darkMode === 'true' ? true: false;
   return (
     <header>
       <AppBar position="static">

--- a/src/Components/LaunchCard/LaunchCard.jsx
+++ b/src/Components/LaunchCard/LaunchCard.jsx
@@ -92,9 +92,11 @@ export default function LaunchCard({ launch }) {
               {probability}% Chance of Launch
             </Typography>
           )}
-          <Typography paragraph>
-            {missions[0].description}
-          </Typography>
+          {missions[0] && (
+            <Typography paragraph>
+              {missions[0].description}
+            </Typography>
+          )}
         </CardContent>
         <CardContent>
           {/* <CardMedia
@@ -104,7 +106,9 @@ export default function LaunchCard({ launch }) {
           /> */}
           <Typography paragraph>Rocket: {rocket.familyname}</Typography>
           {rocket.configuration && <Typography paragraph>Configuration: {rocket.configuration}</Typography>}
-          <Typography paragraph>Launching from  {location.pads[0].name}</Typography>
+          <Typography paragraph>Launching from</Typography>
+          <Typography paragraph>{location.name}</Typography>
+          <Typography paragraph>{location.pads[0].name}</Typography>
           <Typography paragraph>Status: {launch.status === 1 ? 'Green': launch.status ===2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</Typography>
           {(tbddate === 1 || tbdtime === 1) ? (
             <React.Fragment>

--- a/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
+++ b/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { Button, ButtonGroup } from '@material-ui/core';
 
 
-export default function LaunchTimeframeToggle() {
+export default function LaunchTimeframeToggle({ setTimeFrame }) {
   return (
-    <div>
+    <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }}>
       <ButtonGroup variant="contained" aria-label="Time frame buttons" size="small">
-        <Button>Upcoming</Button>
-        <Button>Already Happened</Button>
+        <Button onClick={() => setTimeFrame(false)}>Upcoming</Button>
+        <Button onClick={() => setTimeFrame(true)}>Already Happened</Button>
       </ButtonGroup>
     </div>
   );

--- a/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
+++ b/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Button, ButtonGroup } from '@material-ui/core';
+
+
+export default function LaunchTimeframeToggle() {
+  return (
+    <div>
+      <ButtonGroup variant="contained" aria-label="Time frame buttons" size="small">
+        <Button>Upcoming</Button>
+        <Button>Already Happened</Button>
+      </ButtonGroup>
+    </div>
+  );
+}

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,5 +1,5 @@
 export const getUpcomingLaunches = async (num) => {
-  try{
+  try {
     const response = await fetch(`https://launchlibrary.net/1.3/launch/next/${num}`);
     if(response.status === 200) {
       const launches = await response.json();
@@ -7,5 +7,18 @@ export const getUpcomingLaunches = async (num) => {
     }
   } catch(e) {
     return new Error('There was a problem fetching upcoming launches');
+  }
+}
+
+export const getPastLaunches = async (windowStart, windowEnd) => {
+  try {
+    const response = await fetch(`https://launchlibrary.net/1.3/launch/${windowStart}/${windowEnd}`);
+
+    if(response.status === 200) {
+      const launches = await response.json();
+      return launches;
+    }
+  } catch(e) {
+    return new Error('There was a problem retrieving past launches');
   }
 }


### PR DESCRIPTION
#### What's this PR do?
Implements fetch to retrieve past launches with a supplied start and end date. Adds functionality to the app to display past launches. Adds button group and implements on click functionality to toggle between upcoming and past launches. Adds theme preference to local storage to allow for persistent dark/light mode.
#### Where should the reviewer start?
The user should be able to toggle between upcoming and past launches. When the user selects dark mode or light mode, their preference should be persistent between page reloads.
#### Any background context you want to provide?
May need to update the launch card or create a new component to display past launches, since the relevant information may differ.
#### What are the relevant tickets?
#3 #8 
#### Screenshots (if appropriate)
![Screen Shot 2020-07-06 at 10 55 04 AM](https://user-images.githubusercontent.com/25031031/86614493-b6ad1a80-bf78-11ea-97e8-37b04fbe9074.png)
