### PR TITLE
Card styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,6 +1374,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -25,12 +25,15 @@ class App extends React.Component {
       const pastLaunches = await getPastLaunches(windowStart, windowEnd);
       const localThemePrefs = await localStorage.getItem('darkMode');
       const darkMode = localThemePrefs ? JSON.parse(localThemePrefs): false;
-      await this.setState({
-        upcomingLaunches,
-        pastLaunches,
-        darkMode,
-        loading: false,
-      });
+      
+      setTimeout(() => {
+        this.setState({
+          upcomingLaunches,
+          pastLaunches,
+          darkMode,
+          loading: false,
+        });
+      }, 1000);
     } catch(e) {
       console.log(e);
       this.setState({ error: e, loading: false });

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,6 @@ import LaunchTimeframeToggle from './Components/LaunchTimeframeToggle/LaunchTime
 
 import { Grid, createMuiTheme, ThemeProvider, Typography, CircularProgress } from '@material-ui/core';
 import { red } from '@material-ui/core/colors';
-
 import { getUpcomingLaunches, getPastLaunches } from './apiCalls';
 
 class App extends React.Component {

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import SearchIcon from '@material-ui/icons/Search';
+
 import { Switch } from '@material-ui/core';
-import { makeStyles, Typography, AppBar, Toolbar } from '@material-ui/core';
+import { fade, makeStyles, Typography, AppBar, Toolbar, InputBase, Grid } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {
@@ -8,18 +10,68 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    padding: '0 20px',
+  },
+  search: {
+    display: 'inline-flex',
+    position: 'relative',
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: fade(theme.palette.common.white, 0.15),
+    '&:hover': {
+      backgroundColor: fade(theme.palette.common.white, 0.25),
+    },
+    // marginRight: theme.spacing(2),
+    marginLeft: 0,
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      marginLeft: theme.spacing(3),
+      width: 'auto',
+    },
+    justifySelf: 'center',
+    alignSelf: 'center',
+  },
+  searchIcon: {
+    padding: theme.spacing(0, 2),
+    height: '100%',
+    position: 'absolute',
+    pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  inputRoot: {
+    color: 'inherit',
+  },
+  inputInput: {
+    padding: theme.spacing(1, 1, 1, 0),
+    paddingLeft: `calc(1em + ${theme.spacing(4)}px)`,
+    transition: theme.transitions.create('width'),
+    width: '100%',
+    [theme.breakpoints.up('md')]: {
+      width: '20ch',
+    },
   },
 }));
 
 export default function Header({ darkMode, toggleDarkMode }) {
   const classes = useStyles();
-  const isDarkMode = darkMode === 'true' ? true: false;
   return (
-    <header>
+    <header style={{flexGrow: 1}}>
       <AppBar position="static">
         <Toolbar className={classes.toolbar}>
           <Typography variant="h1">Launch Master</Typography>
+          <div className={classes.search}>
+            <div className={classes.searchIcon}>
+              <SearchIcon />
+            </div>
+            <InputBase
+              placeholder="Search…"
+              classes={{
+                root: classes.inputRoot,
+                input: classes.inputInput,
+              }}
+              inputProps={{ 'aria-label': 'search' }}
+            />
+          </div>
           <div>
             <Typography style={{ display: 'inline'}}>Light</Typography>
             <Switch

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -59,7 +59,7 @@ export default function Header({ darkMode, toggleDarkMode }) {
       <AppBar position="static">
         <Toolbar className={classes.toolbar}>
           <Typography variant="h1">Launch Master</Typography>
-          <div className={classes.search}>
+          {/* <div className={classes.search}>
             <div className={classes.searchIcon}>
               <SearchIcon />
             </div>
@@ -71,7 +71,7 @@ export default function Header({ darkMode, toggleDarkMode }) {
               }}
               inputProps={{ 'aria-label': 'search' }}
             />
-          </div>
+          </div> */}
           <div>
             <Typography style={{ display: 'inline'}}>Light</Typography>
             <Switch

--- a/src/Components/LaunchCard/LaunchCard.jsx
+++ b/src/Components/LaunchCard/LaunchCard.jsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
 export default function LaunchCard({ launch }) {
   const classes = useStyles();
   const [expanded, setExpanded] = React.useState(false);
-  const { name, net, missions, rocket, probability, location, tbddate, tbdtime, lsp } = launch;
+  const { name, net, missions, rocket, probability, location, tbddate, tbdtime } = launch;
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
@@ -51,29 +51,23 @@ export default function LaunchCard({ launch }) {
     <Card className={classes.root}>
       <CardHeader
         title={name}
-        subheader={net}
-      />
-      {/* <CardContent>
-        <Typography variant="body1" component="p">
-          {missions[0].name}
-        </Typography>
-      </CardContent> */}
-      {/* <CardContent>
-        <Typography variant="body2" color="textSecondary" component="p">
-          {missions[0].description}
-        </Typography>
-      </CardContent> */}
-      <CardActions disableSpacing>
-        { launch.vidURLs.length > 0 && (
+        subheader={(tbddate === 1 || tbdtime === 1) ? `Unconfirmed: ${net}`: net}
+        action={launch.vidURLs.length > 0 ? (
           <a href={launch.vidURLs[0]} target="_blank" rel="noopener noreferrer">
             <IconButton aria-label="watch live">
               <VideoCam fontSize="large"/>
             </IconButton>
           </a>
-        )}
-        {/* <IconButton aria-label="share">
-          <ShareIcon />
-        </IconButton> */}
+        ): null}
+      />
+      {launch.failreason && (
+        <CardContent>
+          <Typography>
+            {launch.failreason}
+          </Typography>
+        </CardContent>
+      )}
+      <CardActions disableSpacing>
         <IconButton
           className={clsx(classes.expand, {
             [classes.expandOpen]: expanded,
@@ -99,28 +93,13 @@ export default function LaunchCard({ launch }) {
           )}
         </CardContent>
         <CardContent>
-          {/* <CardMedia
-            className={classes.media}
-            image={rocket.imageURL}
-            title="Paella dish"
-          /> */}
           <Typography paragraph>Rocket: {rocket.familyname}</Typography>
           {rocket.configuration && <Typography paragraph>Configuration: {rocket.configuration}</Typography>}
           <Typography paragraph>Launching from</Typography>
           <Typography paragraph>{location.name}</Typography>
           <Typography paragraph>{location.pads[0].name}</Typography>
           <Typography paragraph>Status: {launch.status === 1 ? 'Green': launch.status ===2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</Typography>
-          {(tbddate === 1 || tbdtime === 1) ? (
-            <React.Fragment>
-              <Typography paragraph>Confirmed:</Typography>
-              <CancelIcon />
-            </React.Fragment>
-          ): (
-            <React.Fragment>
-              <Typography paragraph>Confirmed:</Typography>
-              <CheckCircleIcon />
-            </React.Fragment>
-          )}
+          {launch.failreason && <Typography paragraph>{launch.failreason}</Typography>}
         </CardContent>
       </Collapse>
     </Card>

--- a/src/Components/LaunchCard/LaunchCard.jsx
+++ b/src/Components/LaunchCard/LaunchCard.jsx
@@ -1,19 +1,25 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
-import CardMedia from '@material-ui/core/CardMedia';
-import CardContent from '@material-ui/core/CardContent';
-import CardActions from '@material-ui/core/CardActions';
-import Collapse from '@material-ui/core/Collapse';
-import IconButton from '@material-ui/core/IconButton';
-import Typography from '@material-ui/core/Typography';
-import FavoriteIcon from '@material-ui/icons/Favorite';
-import ShareIcon from '@material-ui/icons/Share';
+import { makeStyles } from '@material-ui/core/styles';
+import {
+  Card,
+  CardHeader,
+  CardMedia,
+  CardContent,
+  CardActions,
+  Collapse,
+  IconButton,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from '@material-ui/core';
+
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import CancelIcon from '@material-ui/icons/Cancel';
-import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import VideoCam from '@material-ui/icons/Videocam';
 
 const useStyles = makeStyles((theme) => ({
@@ -36,6 +42,9 @@ const useStyles = makeStyles((theme) => ({
   expandOpen: {
     transform: 'rotate(180deg)',
   },
+  table: {
+    marginBottom: theme.spacing(3),
+  }
 }));
 
 export default function LaunchCard({ launch }) {
@@ -92,15 +101,39 @@ export default function LaunchCard({ launch }) {
             </Typography>
           )}
         </CardContent>
-        <CardContent>
+        {/* <CardContent>
           <Typography paragraph>Rocket: {rocket.familyname}</Typography>
           {rocket.configuration && <Typography paragraph>Configuration: {rocket.configuration}</Typography>}
           <Typography paragraph>Launching from</Typography>
-          <Typography paragraph>{location.name}</Typography>
+          {location.pads.length <= 0 && <Typography paragraph>{location.name}</Typography>}
           <Typography paragraph>{location.pads[0].name}</Typography>
           <Typography paragraph>Status: {launch.status === 1 ? 'Green': launch.status ===2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</Typography>
           {launch.failreason && <Typography paragraph>{launch.failreason}</Typography>}
-        </CardContent>
+        </CardContent> */}
+        <TableContainer component={Paper}>
+          <Table className={classes.table} aria-label="Launch Information">
+            <TableHead>
+              <TableRow>
+                <TableCell>Rocket Name</TableCell>
+                <TableCell>Configuration</TableCell>
+                <TableCell>Launch Location</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Date</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell component="th" scope="row">
+                  {rocket.familyname}
+                </TableCell>
+                <TableCell>{rocket.configuration ? rocket.configuration: 'Uknown'}</TableCell>
+                <TableCell>{location.pads.length > 0 ? location.pads[0].name: location.name}</TableCell>
+                <TableCell>{launch.status === 1 ? 'Green': launch.status ===2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</TableCell>
+                <TableCell>{net}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
       </Collapse>
     </Card>
   );

--- a/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
+++ b/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
@@ -11,11 +11,7 @@ export default function LaunchTimeframeToggle({ setTimeFrame }) {
   }
 
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }}>
-      {/* <ButtonGroup variant="contained" aria-label="Time frame buttons" size="small">
-        <Button onClick={() => setTimeFrame(false)}>Upcoming</Button>
-        <Button onClick={() => setTimeFrame(true)}>Already Happened</Button>
-      </ButtonGroup> */}
+    <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }} aria-label="select upcoming launches or past launches">
       <ToggleButtonGroup
       value={active}
       exclusive

--- a/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
+++ b/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
@@ -1,14 +1,34 @@
 import React from 'react';
-import { Button, ButtonGroup } from '@material-ui/core';
-
+import { Button, ButtonGroup, Typography } from '@material-ui/core';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 
 export default function LaunchTimeframeToggle({ setTimeFrame }) {
+  const [active, setActive] = React.useState('upcoming');
+
+  const handleActive = (event, newActive) => {
+    setActive(newActive);
+  }
+
   return (
     <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }}>
-      <ButtonGroup variant="contained" aria-label="Time frame buttons" size="small">
+      {/* <ButtonGroup variant="contained" aria-label="Time frame buttons" size="small">
         <Button onClick={() => setTimeFrame(false)}>Upcoming</Button>
         <Button onClick={() => setTimeFrame(true)}>Already Happened</Button>
-      </ButtonGroup>
+      </ButtonGroup> */}
+      <ToggleButtonGroup
+      value={active}
+      exclusive
+      onChange={handleActive}
+      aria-label="past or upcoming launch selection"
+    >
+      <ToggleButton value="upcoming" aria-label="upcoming launches" onClick={() => setTimeFrame(false)}>
+        Upcoming
+      </ToggleButton>
+      <ToggleButton value="past" aria-label="past launches" onClick={() => setTimeFrame(true)}>
+        Past
+      </ToggleButton>
+    </ToggleButtonGroup>
     </div>
   );
 }


### PR DESCRIPTION
#### What's this PR do?
Adds material lab to bring in active button states. Moves video links if they exist to the main card, instead of having it in the collapsable content. Implements active states for past/previous launch buttons. Adds a basic search bar. Search bar is currently commented out until functionality is implemented. Adds main fetch in App.js into a set timeout to ensure that the load time isn't too quick. Move launch data into tables to improve UI cleanliness.
#### Any background context you want to provide?
Search bar functionality will need to be implemented but styling is mostly complete. Header styles will need to be adjusted to center the search bar.
#### What are the relevant tickets?
#6 
#### Screenshots (if appropriate)
![Screen Shot 2020-07-12 at 1 36 15 PM](https://user-images.githubusercontent.com/25031031/87253977-c62ed680-c444-11ea-9498-b67f50ebeccd.png)
![Screen Shot 2020-07-12 at 1 36 41 PM](https://user-images.githubusercontent.com/25031031/87253999-d47cf280-c444-11ea-91ec-2331fd19b16f.png)
