### PR TITLE
Num launches

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,13 +15,14 @@ class App extends React.Component {
     error: null,
     loading: true,
     timeframe: false,
+    numResults: 10,
   };
 
   componentDidMount = async () => {
     try {
       const windowEnd = this.getTodaysDate();
       const windowStart = this.getOneMonthBackDate();
-      const upcomingLaunches = await getUpcomingLaunches(10);
+      const upcomingLaunches = await getUpcomingLaunches(50);
       const pastLaunches = await getPastLaunches(windowStart, windowEnd);
       const localThemePrefs = await localStorage.getItem('darkMode');
       const darkMode = localThemePrefs ? JSON.parse(localThemePrefs): false;
@@ -54,6 +55,10 @@ class App extends React.Component {
     this.setState({ timeframe: bool });
   }
 
+  setNumResults = (num) => {
+    this.setState({ numResults: num });
+  }
+
   getTodaysDate = () => {
     const today = new Date();
     let day = today.getDate();
@@ -84,16 +89,17 @@ class App extends React.Component {
   }
 
   renderUpcomingLaunches = () => {
-    const { upcomingLaunches } = this.state;
+    const { upcomingLaunches, numResults } = this.state;
 
     if(upcomingLaunches) {
-      return upcomingLaunches.launches.map((launch) => {
+      const launchCards = upcomingLaunches.launches.map((launch, i) => {
         return (
           <Grid item direction="column" xs={12} md={10} lg={8} key={launch.name}>
             <LaunchCard launch={launch}/>
           </Grid>
         );
       });
+      return launchCards.slice(0, numResults);
     } else {
       return <h1>We couldn't find any upcoming launches...</h1>;
     }
@@ -117,7 +123,7 @@ class App extends React.Component {
   
   
   render() {
-    const { darkMode, loading, timeframe } = this.state;
+    const { darkMode, loading, timeframe, numResults } = this.state;
 
     const theme = createMuiTheme({
       palette: {
@@ -144,7 +150,7 @@ class App extends React.Component {
       <ThemeProvider theme={theme}>
         <main style={{ backgroundColor: darkMode ? '#000': '#fafafa' }}>
           <Header toggleDarkMode={this.toggleDarkMode} darkMode={darkMode}/>
-            <LaunchTimeframeToggle setTimeFrame={this.setTimeFrame}/>
+            <LaunchTimeframeToggle setTimeFrame={this.setTimeFrame} setNumResults={this.setNumResults} numResults={numResults}/>
             <Grid
               container
               justify="center"

--- a/src/Components/LaunchCard/LaunchCard.jsx
+++ b/src/Components/LaunchCard/LaunchCard.jsx
@@ -95,21 +95,14 @@ export default function LaunchCard({ launch }) {
               {probability}% Chance of Launch
             </Typography>
           )}
-          {missions[0] && (
+          {missions.length > 0 ? (
             <Typography paragraph>
               {missions[0].description}
             </Typography>
+          ): (
+            <Typography paragraph>No description available</Typography>
           )}
         </CardContent>
-        {/* <CardContent>
-          <Typography paragraph>Rocket: {rocket.familyname}</Typography>
-          {rocket.configuration && <Typography paragraph>Configuration: {rocket.configuration}</Typography>}
-          <Typography paragraph>Launching from</Typography>
-          {location.pads.length <= 0 && <Typography paragraph>{location.name}</Typography>}
-          <Typography paragraph>{location.pads[0].name}</Typography>
-          <Typography paragraph>Status: {launch.status === 1 ? 'Green': launch.status ===2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</Typography>
-          {launch.failreason && <Typography paragraph>{launch.failreason}</Typography>}
-        </CardContent> */}
         <TableContainer component={Paper}>
           <Table className={classes.table} aria-label="Launch Information">
             <TableHead>

--- a/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
+++ b/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
@@ -1,30 +1,65 @@
 import React from 'react';
-import { Button, ButtonGroup, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { FormControl, InputLabel, Select, MenuItem } from '@material-ui/core';
 import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 
-export default function LaunchTimeframeToggle({ setTimeFrame }) {
+export default function LaunchTimeframeToggle({ setTimeFrame, setNumResults, numResults }) {
   const [active, setActive] = React.useState('upcoming');
+
+  const useStyles = makeStyles((theme) => ({
+    buttonContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      marginTop: theme.spacing(4), 
+    },
+    formControl: {
+      margin: theme.spacing(1),
+      minWidth: 120,
+      justifySelf: 'flex-end',
+    },
+    selectEmpty: {
+      marginTop: theme.spacing(2),
+    },
+  }));
 
   const handleActive = (event, newActive) => {
     setActive(newActive);
   }
 
+  const handleNumResults = (e) => {
+    setNumResults(e.target.value);
+  }
+
+  const classes = useStyles();
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }} aria-label="select upcoming launches or past launches">
+    <div className={classes.buttonContainer} aria-label="select upcoming launches or past launches">
       <ToggleButtonGroup
-      value={active}
-      exclusive
-      onChange={handleActive}
-      aria-label="past or upcoming launch selection"
-    >
-      <ToggleButton value="upcoming" aria-label="upcoming launches" onClick={() => setTimeFrame(false)}>
-        Upcoming
-      </ToggleButton>
-      <ToggleButton value="past" aria-label="past launches" onClick={() => setTimeFrame(true)}>
-        Past
-      </ToggleButton>
-    </ToggleButtonGroup>
+        value={active}
+        exclusive
+        onChange={handleActive}
+        aria-label="past or upcoming launch selection"
+      >
+        <ToggleButton value="upcoming" aria-label="upcoming launches" onClick={() => setTimeFrame(false)}>
+          Upcoming
+        </ToggleButton>
+        <ToggleButton value="past" aria-label="past launches" onClick={() => setTimeFrame(true)}>
+          Past
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <FormControl variant="filled" className={classes.formControl}>
+        <InputLabel id="demo-simple-select-filled-label">Results</InputLabel>
+        <Select
+          labelId="demo-simple-select-filled-label"
+          id="demo-simple-select-filled"
+          value={numResults}
+          onChange={handleNumResults}
+        >
+          <MenuItem value={10}>10</MenuItem>
+          <MenuItem value={25}>25</MenuItem>
+          <MenuItem value={50}>50</MenuItem>
+        </Select>
+      </FormControl>
     </div>
   );
 }

--- a/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
+++ b/src/Components/LaunchTimeframeToggle/LaunchTimeframeToggle.jsx
@@ -47,19 +47,21 @@ export default function LaunchTimeframeToggle({ setTimeFrame, setNumResults, num
           Past
         </ToggleButton>
       </ToggleButtonGroup>
-      <FormControl variant="filled" className={classes.formControl}>
-        <InputLabel id="demo-simple-select-filled-label">Results</InputLabel>
-        <Select
-          labelId="demo-simple-select-filled-label"
-          id="demo-simple-select-filled"
-          value={numResults}
-          onChange={handleNumResults}
-        >
-          <MenuItem value={10}>10</MenuItem>
-          <MenuItem value={25}>25</MenuItem>
-          <MenuItem value={50}>50</MenuItem>
-        </Select>
-      </FormControl>
+      {active === 'upcoming' ? (
+        <FormControl variant="filled" className={classes.formControl}>
+          <InputLabel id="demo-simple-select-filled-label">Results</InputLabel>
+          <Select
+            labelId="demo-simple-select-filled-label"
+            id="demo-simple-select-filled"
+            value={numResults}
+            onChange={handleNumResults}
+          >
+            <MenuItem value={10}>10</MenuItem>
+            <MenuItem value={25}>25</MenuItem>
+            <MenuItem value={50}>50</MenuItem>
+          </Select>
+        </FormControl>
+      ): null}
     </div>
   );
 }


### PR DESCRIPTION
#### What's this PR do?
Implement functionality that allows the user to select how many results they would like to see. Number of results selection is only visible when showing upcoming launches. Still needs some positioning work.
#### Where should the reviewer start?
On page load, you should see 10 results. You should be able to switch between 10, 25, and 50 results. You should see the additional results immediately.
#### What are the relevant tickets?
#2 
#### Screenshots (if appropriate)
![Screen Shot 2020-07-14 at 6 14 27 PM](https://user-images.githubusercontent.com/25031031/87485233-e950b600-c5fd-11ea-8592-038b5cfe5c48.png)