### PR TITLE
Launch card info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ cache:
   - node_modules
 
 before_script:
-  - echo 'America/Menominee' | sudo tee /etc/timezone
-  - sudo dpkg-reconfigure --frontend noninteractive tzdata
-  - sudo ntpdate ntp.ubuntu.com
+  - sudo timedatectl set-timezone America/Menominee
 
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ cache:
 before_script:
   - echo 'US/Central' | sudo tee /etc/timezone
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
+  - sudo ntpdate ntp.ubuntu.com
+
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ cache:
   - node_modules
 script:
   - npm test
-  - npm run deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,5 @@ node_js:
 cache:
   directories:
   - node_modules
-
-before_script:
-  - sudo timedatectl set-timezone America/Menominee
-
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,9 @@ node_js:
 cache:
   directories:
   - node_modules
+
+before_script:
+  - echo 'US/Central' | sudo tee /etc/timezone
+  - sudo dpkg-reconfigure --frontend noninteractive tzdata
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   - node_modules
 
 before_script:
-  - echo 'US/Central' | sudo tee /etc/timezone
+  - echo 'America/Menominee' | sudo tee /etc/timezone
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
   - sudo ntpdate ntp.ubuntu.com
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ cache:
   - node_modules
 script:
   - npm test
+  - npm run deploy

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import LaunchCard from './Components/LaunchCard/LaunchCard';
 import LaunchOptionsBar from './Components/LaunchOptionsBar/LaunchOptionsBar';
 
 import { Grid, createMuiTheme, ThemeProvider, Typography, CircularProgress } from '@material-ui/core';
-import { red } from '@material-ui/core/colors';
+import { red, blue } from '@material-ui/core/colors';
 import { getUpcomingLaunches, getPastLaunches } from './apiCalls';
 
 class App extends React.Component {
@@ -95,7 +95,7 @@ class App extends React.Component {
       const launchCards = upcomingLaunches.launches.map((launch, i) => {
         return (
           <Grid item direction="column" xs={12} md={10} lg={8} key={launch.name}>
-            <LaunchCard launch={launch}/>
+            <LaunchCard launch={launch} past={false}/>
           </Grid>
         );
       });
@@ -112,7 +112,7 @@ class App extends React.Component {
       return pastLaunches.launches.map((launch) => {
         return (
           <Grid item direction="column" xs={12} md={10} lg={8} key={launch.name}>
-            <LaunchCard launch={launch}/>
+            <LaunchCard launch={launch} past={true}/>
           </Grid>
         );
       });
@@ -120,7 +120,6 @@ class App extends React.Component {
       return <h1>We couldn't find any past launches...</h1>;
     }
   }
-  
   
   render() {
     const { darkMode, loading, timeframe, numResults } = this.state;
@@ -142,7 +141,13 @@ class App extends React.Component {
           color: darkMode ? red[400]: '#fff',
           fontFamily: 'Pacifico, Roboto',
           fontSize: 48,
-        }
+        },
+        h4: {
+          color: darkMode ? red[400]: '#000',
+          fontSize: 20,
+          fontFamily: 'Roboto',
+          padding: '1em',
+        },
       }
     });
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -59,7 +59,6 @@ describe('App', () => {
 
   it('getOneMonthBackDate should return a ten digit date', () => {
     const oneMonthBackDate = wrapper.instance().getOneMonthBackDate();
-    console.log(oneMonthBackDate);
     expect(oneMonthBackDate.length).toEqual(10);
-  })
+  });
 });

--- a/src/Components/LaunchCard/LaunchCard.jsx
+++ b/src/Components/LaunchCard/LaunchCard.jsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-export default function LaunchCard({ launch }) {
+export default function LaunchCard({ launch, past }) {
   const classes = useStyles();
   const [expanded, setExpanded] = React.useState(false);
   const { name, net, missions, rocket, probability, location, tbddate, tbdtime } = launch;
@@ -56,11 +56,13 @@ export default function LaunchCard({ launch }) {
     setExpanded(!expanded);
   };
 
+  const time = new Date(net).toString();
+
   return (
     <Card className={classes.root}>
       <CardHeader
         title={name}
-        subheader={(tbddate === 1 || tbdtime === 1) ? `Unconfirmed: ${net}`: net}
+        subheader={(tbddate === 1 || tbdtime === 1) ? `Unconfirmed: ${time}`: time}
         action={launch.vidURLs.length > 0 ? (
           <a href={launch.vidURLs[0]} target="_blank" rel="noopener noreferrer">
             <IconButton aria-label="watch live">
@@ -76,6 +78,30 @@ export default function LaunchCard({ launch }) {
           </Typography>
         </CardContent>
       )}
+      <CardContent>
+          {(probability > -1 && !past) && (
+            <Typography paragraph>
+              {probability}% Chance of Launch
+            </Typography>
+          )}
+          {missions.length > 0 ? (
+            <React.Fragment>
+              <Typography variant="h4">
+                {missions[0].typeName} Mission
+              </Typography>
+              <Typography paragraph>
+                {missions[0].description}
+              </Typography>
+            </React.Fragment>
+          ): (
+            <Typography paragraph>No description available</Typography>
+          )}
+          {launch.infoURLs.length > 0 && launch.infoURLs.map((info) => (
+            <a href={info} target="_blank" rel="noopener noreferrer" key={info}>
+              {info}
+            </a>
+          ))}
+        </CardContent>
       <CardActions disableSpacing>
         <IconButton
           className={clsx(classes.expand, {
@@ -89,20 +115,6 @@ export default function LaunchCard({ launch }) {
         </IconButton>
       </CardActions>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
-        <CardContent>
-          {probability > 0 && (
-            <Typography paragraph>
-              {probability}% Chance of Launch
-            </Typography>
-          )}
-          {missions.length > 0 ? (
-            <Typography paragraph>
-              {missions[0].description}
-            </Typography>
-          ): (
-            <Typography paragraph>No description available</Typography>
-          )}
-        </CardContent>
         <TableContainer component={Paper}>
           <Table className={classes.table} aria-label="Launch Information">
             <TableHead>
@@ -119,10 +131,10 @@ export default function LaunchCard({ launch }) {
                 <TableCell component="th" scope="row">
                   {rocket.familyname}
                 </TableCell>
-                <TableCell>{rocket.configuration ? rocket.configuration: 'Uknown'}</TableCell>
+                <TableCell>{rocket.configuration ? rocket.configuration: 'Unknown'}</TableCell>
                 <TableCell>{location.pads.length > 0 ? location.pads[0].name: location.name}</TableCell>
-                <TableCell>{launch.status === 1 ? 'Green': launch.status ===2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</TableCell>
-                <TableCell>{net}</TableCell>
+                <TableCell>{launch.status === 1 ? 'Green': launch.status === 2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</TableCell>
+                <TableCell>{time}</TableCell>
               </TableRow>
             </TableBody>
           </Table>

--- a/src/Components/LaunchCard/LaunchCard.jsx
+++ b/src/Components/LaunchCard/LaunchCard.jsx
@@ -56,13 +56,11 @@ export default function LaunchCard({ launch, past }) {
     setExpanded(!expanded);
   };
 
-  const time = new Date(net).toString();
-
   return (
     <Card className={classes.root}>
       <CardHeader
         title={name}
-        subheader={(tbddate === 1 || tbdtime === 1) ? `Unconfirmed: ${time}`: time}
+        subheader={(tbddate === 1 || tbdtime === 1) ? `Unconfirmed: ${net}`: net}
         action={launch.vidURLs.length > 0 ? (
           <a href={launch.vidURLs[0]} target="_blank" rel="noopener noreferrer">
             <IconButton aria-label="watch live">
@@ -134,7 +132,7 @@ export default function LaunchCard({ launch, past }) {
                 <TableCell>{rocket.configuration ? rocket.configuration: 'Unknown'}</TableCell>
                 <TableCell>{location.pads.length > 0 ? location.pads[0].name: location.name}</TableCell>
                 <TableCell>{launch.status === 1 ? 'Green': launch.status === 2 ? 'Red': launch.status === 3 ? 'Succeeded' : 'Failed'}</TableCell>
-                <TableCell>{time}</TableCell>
+                <TableCell>{net}</TableCell>
               </TableRow>
             </TableBody>
           </Table>

--- a/src/Components/LaunchCard/__snapshots__/LaunchCard.test.js.snap
+++ b/src/Components/LaunchCard/__snapshots__/LaunchCard.test.js.snap
@@ -6,9 +6,29 @@ exports[`LaunchCard Component should show alternate text or not display elements
 >
   <WithStyles(ForwardRef(CardHeader))
     action={null}
-    subheader="Unconfirmed: July 15, 2020 13:00:00 UTC"
+    subheader="Unconfirmed: Wed Jul 15 2020 08:00:00 GMT-0500 (Central Daylight Time)"
     title="Minotaur IV | NROL-129"
   />
+  <WithStyles(ForwardRef(CardContent))>
+    <WithStyles(ForwardRef(Typography))
+      paragraph={true}
+    >
+      % Chance of Launch
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      paragraph={true}
+    >
+      No description available
+    </WithStyles(ForwardRef(Typography))>
+    <a
+      href="https://www.nro.gov/Portals/65/documents/news/Press%20Kit_Launch_NROL-129.pdf?ver=2020-07-07-134345-553"
+      key="https://www.nro.gov/Portals/65/documents/news/Press%20Kit_Launch_NROL-129.pdf?ver=2020-07-07-134345-553"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      https://www.nro.gov/Portals/65/documents/news/Press%20Kit_Launch_NROL-129.pdf?ver=2020-07-07-134345-553
+    </a>
+  </WithStyles(ForwardRef(CardContent))>
   <WithStyles(ForwardRef(CardActions))
     disableSpacing={true}
   >
@@ -26,13 +46,6 @@ exports[`LaunchCard Component should show alternate text or not display elements
     timeout="auto"
     unmountOnExit={true}
   >
-    <WithStyles(ForwardRef(CardContent))>
-      <WithStyles(ForwardRef(Typography))
-        paragraph={true}
-      >
-        No description available
-      </WithStyles(ForwardRef(Typography))>
-    </WithStyles(ForwardRef(CardContent))>
     <WithStyles(ForwardRef(TableContainer))
       component={
         Object {
@@ -383,7 +396,7 @@ exports[`LaunchCard Component should show alternate text or not display elements
               Minotaur
             </WithStyles(ForwardRef(TableCell))>
             <WithStyles(ForwardRef(TableCell))>
-              Uknown
+              Unknown
             </WithStyles(ForwardRef(TableCell))>
             <WithStyles(ForwardRef(TableCell))>
               Wallops Island, Virginia, USA
@@ -392,7 +405,7 @@ exports[`LaunchCard Component should show alternate text or not display elements
               Red
             </WithStyles(ForwardRef(TableCell))>
             <WithStyles(ForwardRef(TableCell))>
-              July 15, 2020 13:00:00 UTC
+              Wed Jul 15 2020 08:00:00 GMT-0500 (Central Daylight Time)
             </WithStyles(ForwardRef(TableCell))>
           </WithStyles(ForwardRef(TableRow))>
         </WithStyles(ForwardRef(TableBody))>
@@ -422,13 +435,40 @@ exports[`LaunchCard should match snapshot when probabily, vidURLs, launch confir
         </ForwardRef(WithStyles)>
       </a>
     }
-    subheader="July 15, 2020 13:00:00 UTC"
+    subheader="Wed Jul 15 2020 08:00:00 GMT-0500 (Central Daylight Time)"
     title="Minotaur IV | NROL-129"
   />
   <WithStyles(ForwardRef(CardContent))>
     <WithStyles(ForwardRef(Typography))>
       The launch failed spontaneously
     </WithStyles(ForwardRef(Typography))>
+  </WithStyles(ForwardRef(CardContent))>
+  <WithStyles(ForwardRef(CardContent))>
+    <WithStyles(ForwardRef(Typography))
+      paragraph={true}
+    >
+      90
+      % Chance of Launch
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      variant="h4"
+    >
+      Government/Top Secret
+       Mission
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      paragraph={true}
+    >
+      Classified payload for the U.S. National Reconnaissance Office.
+    </WithStyles(ForwardRef(Typography))>
+    <a
+      href="https://www.nro.gov/Portals/65/documents/news/Press%20Kit_Launch_NROL-129.pdf?ver=2020-07-07-134345-553"
+      key="https://www.nro.gov/Portals/65/documents/news/Press%20Kit_Launch_NROL-129.pdf?ver=2020-07-07-134345-553"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      https://www.nro.gov/Portals/65/documents/news/Press%20Kit_Launch_NROL-129.pdf?ver=2020-07-07-134345-553
+    </a>
   </WithStyles(ForwardRef(CardContent))>
   <WithStyles(ForwardRef(CardActions))
     disableSpacing={true}
@@ -447,19 +487,6 @@ exports[`LaunchCard should match snapshot when probabily, vidURLs, launch confir
     timeout="auto"
     unmountOnExit={true}
   >
-    <WithStyles(ForwardRef(CardContent))>
-      <WithStyles(ForwardRef(Typography))
-        paragraph={true}
-      >
-        90
-        % Chance of Launch
-      </WithStyles(ForwardRef(Typography))>
-      <WithStyles(ForwardRef(Typography))
-        paragraph={true}
-      >
-        Classified payload for the U.S. National Reconnaissance Office.
-      </WithStyles(ForwardRef(Typography))>
-    </WithStyles(ForwardRef(CardContent))>
     <WithStyles(ForwardRef(TableContainer))
       component={
         Object {
@@ -819,7 +846,7 @@ exports[`LaunchCard should match snapshot when probabily, vidURLs, launch confir
               Green
             </WithStyles(ForwardRef(TableCell))>
             <WithStyles(ForwardRef(TableCell))>
-              July 15, 2020 13:00:00 UTC
+              Wed Jul 15 2020 08:00:00 GMT-0500 (Central Daylight Time)
             </WithStyles(ForwardRef(TableCell))>
           </WithStyles(ForwardRef(TableRow))>
         </WithStyles(ForwardRef(TableBody))>

--- a/src/Components/LaunchCard/__snapshots__/LaunchCard.test.js.snap
+++ b/src/Components/LaunchCard/__snapshots__/LaunchCard.test.js.snap
@@ -6,7 +6,7 @@ exports[`LaunchCard Component should show alternate text or not display elements
 >
   <WithStyles(ForwardRef(CardHeader))
     action={null}
-    subheader="Unconfirmed: Wed Jul 15 2020 08:00:00 GMT-0500 (Central Daylight Time)"
+    subheader="Unconfirmed: July 15, 2020 13:00:00 UTC"
     title="Minotaur IV | NROL-129"
   />
   <WithStyles(ForwardRef(CardContent))>
@@ -405,7 +405,7 @@ exports[`LaunchCard Component should show alternate text or not display elements
               Red
             </WithStyles(ForwardRef(TableCell))>
             <WithStyles(ForwardRef(TableCell))>
-              Wed Jul 15 2020 08:00:00 GMT-0500 (Central Daylight Time)
+              July 15, 2020 13:00:00 UTC
             </WithStyles(ForwardRef(TableCell))>
           </WithStyles(ForwardRef(TableRow))>
         </WithStyles(ForwardRef(TableBody))>
@@ -435,7 +435,7 @@ exports[`LaunchCard should match snapshot when probabily, vidURLs, launch confir
         </ForwardRef(WithStyles)>
       </a>
     }
-    subheader="Wed Jul 15 2020 08:00:00 GMT-0500 (Central Daylight Time)"
+    subheader="July 15, 2020 13:00:00 UTC"
     title="Minotaur IV | NROL-129"
   />
   <WithStyles(ForwardRef(CardContent))>
@@ -846,7 +846,7 @@ exports[`LaunchCard should match snapshot when probabily, vidURLs, launch confir
               Green
             </WithStyles(ForwardRef(TableCell))>
             <WithStyles(ForwardRef(TableCell))>
-              Wed Jul 15 2020 08:00:00 GMT-0500 (Central Daylight Time)
+              July 15, 2020 13:00:00 UTC
             </WithStyles(ForwardRef(TableCell))>
           </WithStyles(ForwardRef(TableRow))>
         </WithStyles(ForwardRef(TableBody))>

--- a/src/Components/LaunchOptionsBar/LaunchOptionsBar.jsx
+++ b/src/Components/LaunchOptionsBar/LaunchOptionsBar.jsx
@@ -10,13 +10,15 @@ export default function LaunchOptionsBar({ setTimeFrame, setNumResults, numResul
   const useStyles = makeStyles((theme) => ({
     buttonContainer: {
       display: 'flex',
+      flexDirection: 'column',
       justifyContent: 'center',
+      alignItems: 'center',
       marginTop: theme.spacing(4), 
     },
     formControl: {
       margin: theme.spacing(1),
       minWidth: 120,
-      justifySelf: 'flex-end',
+      alignSelf: 'flex-end',
     },
     selectEmpty: {
       marginTop: theme.spacing(2),

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -236,11 +236,13 @@ exports[`App should match snapshot when app is loading 1`] = `
           "lineHeight": 1.167,
         },
         "h4": Object {
-          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
-          "fontSize": "2.125rem",
+          "color": "#000",
+          "fontFamily": "Roboto",
+          "fontSize": 20,
           "fontWeight": 400,
           "letterSpacing": "0.00735em",
           "lineHeight": 1.235,
+          "padding": "1em",
         },
         "h5": Object {
           "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",


### PR DESCRIPTION
#### What's this PR do?
Adds mission type to launch card. Moves description into main card instead of inside the collapsable region. Updates results selection menu to the right side of the page.
#### Screenshots (if appropriate)
![Screen Shot 2020-07-16 at 12 02 58 PM](https://user-images.githubusercontent.com/25031031/87700676-537f6d00-c75c-11ea-8443-59bdd9b9f048.png)